### PR TITLE
Make the currently active menu accessible to events, addressing issue #88

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,22 @@ As the name implies, `ez.removeEvent` also removes your function from the loop.
 
 Sometimes code executed in an event will have changed the contents of the screen. The running menu knows nothing about this, and so when your event ends, it will not refresh the screen. To fix this, you can execute `ez.redraw()` whenever your event routine has done something on the screen. The menu code will then redraw the screen accordingly.
 
+#### Changing the menu from an event
+
+You can get a pointer to the current menu from inside your event code by calling `M5ez::getCurrentMenu()`. Events are not related to any specific menu, so you may get a pointer to different menus at different times durring the program, or even no menu at all (`nullptr`).  
+If you need to confirm what menu you are dealing with, you can retrieve the title you gave the menu when it was created via `ezMenu::getTitle()`, which returns a `String`.  
+An example of a safe usage pattern is:
+
+```c
+ezMenu* cur_menu = M5ez::getCurrentMenu();
+// Test to see if menu exists before testing menu's title
+if(cur_menu && cur_menu->getTitle() == "Desired Menu Title") {
+    cur_menu->setCaption(someItem, someCaption);
+}
+```
+
+Note: If a menu item uses a `simpleFunction` or an `advancedFunction` to display a screen which does not display any menu at all (perhaps only the canvas and buttons are rendered), `M5ez::getCurrentMenu()` will still return the last active menu. You can modify this menu even when it's not displayed, and the changes will be evident when you return from the `simpleFunction` or `advancedFunction`.
+
 &nbsp;
 
 ## Showing messages with msgBox

--- a/src/M5ez.cpp
+++ b/src/M5ez.cpp
@@ -2113,7 +2113,7 @@ constexpr ezCanvas& M5ez::c;
 ezButtons M5ez::buttons;
 constexpr ezButtons& M5ez::b;
 ezSettings M5ez::settings;
-ezMenu* M5ez::currentMenu = nullptr;
+ezMenu* M5ez::_currentMenu = nullptr;
 #ifdef M5EZ_WIFI
 	ezWifi M5ez::wifi;
 	constexpr ezWifi& M5ez::w;
@@ -2186,6 +2186,9 @@ void M5ez::removeEvent(uint16_t (*function)()) {
 bool M5ez::_redraw;
 
 void M5ez::redraw() { _redraw = true; }
+
+ezMenu* M5ez::getCurrentMenu() { return _currentMenu; }
+
 
 static const char * _keydefs[] PROGMEM = {
 	"KB3|qrstu.#SP#KB4|vwxyz,#Del#KB5|More#LCK:|Lock#KB1|abcdefgh#KB2|ijklmnop#Done",	//KB0
@@ -2730,7 +2733,7 @@ ezMenu::ezMenu(String hdr /* = "" */) {
 }
 
 ezMenu::~ezMenu() {
-	if(this == M5ez::currentMenu) M5ez::currentMenu = nullptr;
+	if(this == M5ez::_currentMenu) M5ez::_currentMenu = nullptr;
 }
 
 void ezMenu::txtBig() { _font = ez.theme->menu_big_font; }
@@ -2786,6 +2789,8 @@ bool ezMenu::deleteItem(int16_t index) {
 
 bool ezMenu::deleteItem(String name) { return deleteItem(getItemNum(name)); }
 
+String ezMenu::getTitle() { return _header; }
+
 bool ezMenu::setCaption(int16_t index, String caption) {
 	if (index < 1 || index > _items.size()) return false;
 	index--;	// internally we work with zero-referenced items
@@ -2838,19 +2843,19 @@ void ezMenu::run() {
 
 int16_t ezMenu::runOnce() {
 	int16_t result;
-	M5ez::currentMenu = this;
+	M5ez::_currentMenu = this;
 	if(_items.size() == 0) return 0;
 	if (_selected == -1) _selected = 0;
 	if (!_font)	_font = ez.theme->menu_big_font;	// Cannot be in constructor: ez.theme not there yet
 	for (int16_t n = 0; n < _items.size(); n++) {
 		if (_items[n].image != NULL || _items[n].fs != NULL) {
 			result = _runImagesOnce();
-			if(0 == result) M5ez::currentMenu = nullptr;
+			if(0 == result) M5ez::_currentMenu = nullptr;
 			return result;
 		}
 	}
 	result = _runTextOnce();
-	if(0 == result) M5ez::currentMenu = nullptr;
+	if(0 == result) M5ez::_currentMenu = nullptr;
 	return result;
 }
 

--- a/src/M5ez.h
+++ b/src/M5ez.h
@@ -332,6 +332,7 @@ class ezMenu {
 		void leftOnFirst(String nameAndCaption);
 		void downOnLast(String nameAndCaption);
 		void rightOnLast(String nameAndCaption);
+		String getTitle();
 		int16_t getItemNum(String name);
 		int16_t pick();
 		String pickName(), pickCaption(), pickButton();
@@ -665,7 +666,6 @@ class M5ez {
 		static ezButtons buttons;
 		static constexpr ezButtons& b = buttons;
 		static ezSettings settings;
-		static ezMenu* currentMenu;
 		#ifdef M5EZ_WIFI
 			static ezWifi wifi;
 			static constexpr ezWifi& w = wifi;
@@ -694,6 +694,8 @@ class M5ez {
 		static void removeEvent(uint16_t (*function)());
 		static void redraw();
 
+		static ezMenu* getCurrentMenu();
+
 		// ez.msgBox
 		static String msgBox(String header, String msg, String buttons = "OK", const bool blocking = true, const GFXfont* font = NULL, uint16_t color = NO_COLOR);
 
@@ -721,7 +723,7 @@ class M5ez {
 	private:
 		static std::vector<event_t> _events;
 		static bool _redraw;
-
+		static ezMenu* _currentMenu;
 
 		// ez.textInput
 		static int16_t _text_cursor_x, _text_cursor_y, _text_cursor_h, _text_cursor_w;

--- a/src/M5ez.h
+++ b/src/M5ez.h
@@ -318,6 +318,7 @@ class ezButtons {
 class ezMenu {
 	public:
 		ezMenu(String hdr = "");
+		~ezMenu();
 		bool addItem(String nameAndCaption, void (*simpleFunction)() = NULL, bool (*advancedFunction)(ezMenu* callingMenu) = NULL, void (*drawFunction)(ezMenu* callingMenu, int16_t x, int16_t y, int16_t w, int16_t h) = NULL);
 		bool addItem(const char *image, String nameAndCaption, void (*simpleFunction)() = NULL, bool (*advancedFunction)(ezMenu* callingMenu) = NULL, void (*drawFunction)(ezMenu* callingMenu, int16_t x, int16_t y, int16_t w, int16_t h) = NULL);
 		bool addItem(fs::FS &fs, String path, String nameAndCaption, void (*simpleFunction)() = NULL, bool (*advancedFunction)(ezMenu* callingMenu) = NULL, void (*drawFunction)(ezMenu* callingMenu, int16_t x, int16_t y, int16_t w, int16_t h) = NULL);
@@ -664,6 +665,7 @@ class M5ez {
 		static ezButtons buttons;
 		static constexpr ezButtons& b = buttons;
 		static ezSettings settings;
+		static ezMenu* currentMenu;
 		#ifdef M5EZ_WIFI
 			static ezWifi wifi;
 			static constexpr ezWifi& w = wifi;


### PR DESCRIPTION
This PR adds a static member to the root class: `M5ez::currentMenu`. This makes the currently active menu accessible to event code.
The change has been tested here and by **UT2UH** (originator of issue #88) and was found to adequately address that issue, although it does depart from the original suggestion.

**Design**

* The change is additive and does not modify any existing behavior.  
* `static ezMenu* currentMenu` is added to the class `M5ez`  
* `M5ez::currentMenu` is set on entry to `runOnce()` whenever a menu is rendered/handled.  
* It is cleared when `runOnce()` returns zero, indicating termination.  
* For additional safety, a destructor is added to `ezMenu`, which also clears `M5ez::currentMenu` if and only if it matches `ezMenu`'s `self`. This is safe, it's cheap, and extra safety when caching is a good policy.

**Benefits**

A pointer to the current menu is generally available, as a member of the global `ez`. This makes it possible for ezEvent code to modify the current menu with asynchronous data, addressing the concern in issue #88.  
In addition, it lays the groundwork for developing a non-blocking menu system, where one might call `ez.update()` in the Arduino `loop()` function, which would address other issues.

**Side Effects**

This approach means that if a menu's `simpleFunction` or `advancedFunction` calls code which renders a screen that does not display a menu at all, `M5ez::currentMenu` would still return a pointer to the (hidden) menu. I believe that this may be more of a benefit than a flaw, but it should be documented. If a `simpleFunction` or `advancedFunction` called code which rendered a sub-menu, `M5ez::currentMenu` would accurately track the change as soon as `runOnce()` is called, rendering the menu for the first time.

**Limitations**

There's no way for the event code to identify the current menu; no identifier is available from the public interface. Should a public `String ezMenu::getHdr()` be added to facilitate identification?

**Concerns**

Are there additional safety checks that could be made if we used a public accessor function for a private member variable instead? I believe it would be possible to write code that would leave a dangling `M5ez::currentMenu`, but haven't found a way. I believe that such code is easy to avoid and would likely be buggy in other respects. Suggested approaches are welcome; I will try them.

**Open Issues**

* Make a call on adding `ezMenu::getHdr()` in this PR.
* The scenario described in Side Effects hasn't been adequately tested. I'll do that.  
* I will augment this PR with documentation changes once this approach is approved or improved.
