### PR TITLE
prevent event reentrancy (issue #67)

### DIFF
--- a/src/M5ez.cpp
+++ b/src/M5ez.cpp
@@ -2141,6 +2141,7 @@ ezButtons M5ez::buttons;
 constexpr ezButtons& M5ez::b;
 ezSettings M5ez::settings;
 ezMenu* M5ez::_currentMenu = nullptr;
+bool M5ez::_in_event = false;
 #ifdef M5EZ_WIFI
 	ezWifi M5ez::wifi;
 	constexpr ezWifi& M5ez::w;
@@ -2177,9 +2178,12 @@ void M5ez::begin() {
 void M5ez::yield() {
 	::yield();			// execute the Arduino yield in the root namespace
 	M5.update();
+	if(M5ez::_in_event) return;			// prevent reentrancy
 	for (uint8_t n = 0; n< _events.size(); n++) {
 		if (millis() > _events[n].when) {
+			M5ez::_in_event = true;		// prevent reentrancy
 			uint16_t r = (_events[n].function)();
+			M5ez::_in_event = false;	// prevent reentrancy
 			if (r) {
 				_events[n].when = millis() + r - 1;
 			} else {

--- a/src/M5ez.h
+++ b/src/M5ez.h
@@ -724,6 +724,7 @@ class M5ez {
 		static std::vector<event_t> _events;
 		static bool _redraw;
 		static ezMenu* _currentMenu;
+		static bool _in_event;
 
 		// ez.textInput
 		static int16_t _text_cursor_x, _text_cursor_y, _text_cursor_h, _text_cursor_w;


### PR DESCRIPTION
This is a straight-forward protection against event reentrancy.
M5ez events are on a single thread; only one event is ever being processed at a time. This change allows the underlying systems to idle without calling an event when an event is currently being processed.

**Design**

* Add a private static boolean `M5ez::_in_event` initialized to `false`
* Set  `M5ez::_in_event` immediately before dispatching an event and clear it immediately on return
* On entry to `M5ez::yield()` (where events are processed) process `::yield()` and `M5.update()` as normal, then return if  `M5ez::_in_event` is set.

**Benefits**

* Fixes the example issue provided in issue #67 
* Makes events more robust
* No change to public interface of functional model
* No change to docs required

**Risks**

This is a risk-free change and represents a well-worn design pattern.

**Outstanding Issues**

Have not contacted customer yet; will do that next.
My testing is complete, no doc changes needed, no other outstanding issues.
