### PR TITLE
Eliminate warnings: escape \ in two _keydefs

### DIFF
--- a/src/M5ez.cpp
+++ b/src/M5ez.cpp
@@ -2235,10 +2235,10 @@ static const char * _keydefs[] PROGMEM = {
 	"KB11|1-5.#SP#KB12|6-0,#Del#KB13|More#LCK:NUM|Lock###Done",							//KB10
 	"1#2#3#4#5#,###Back",																//KB11
 	"6#7#8#9#0#.###Back",																//KB12
-	"KB14|!?:;\\#$^&#SP#KB15|*()_-+=\|#Del#KB0|More#LCK:SYM|Lock#KB16|'\"`@%\\/#KB17|<>{}[]()#Done",	//KB13
+	"KB14|!?:;\\#$^&#SP#KB15|*()_-+=\\|#Del#KB0|More#LCK:SYM|Lock#KB16|'\"`@%\\/#KB17|<>{}[]()#Done",	//KB13
 	"!#?#:#;#\\##$#^#&#Back",															//KB14
 	"*#(#)#_#-#+#=#\\|#Back",															//KB15
-	"'#\"#`#@#%#/#\##Back",																//KB16
+	"'#\"#`#@#%#/#\\##Back",																//KB16
 	"<#>#{#}#[#]#(#)#Back",																//KB17
 	".#,#Del##Done#"																	//KB18
 	

--- a/src/M5ez.cpp
+++ b/src/M5ez.cpp
@@ -2238,7 +2238,7 @@ static const char * _keydefs[] PROGMEM = {
 	"KB14|!?:;\\#$^&#SP#KB15|*()_-+=\\|#Del#KB0|More#LCK:SYM|Lock#KB16|'\"`@%\\/#KB17|<>{}[]()#Done",	//KB13
 	"!#?#:#;#\\##$#^#&#Back",															//KB14
 	"*#(#)#_#-#+#=#\\|#Back",															//KB15
-	"'#\"#`#@#%#/#\\##Back",																//KB16
+	"'#\"#`#@#%#/###Back",																//KB16
 	"<#>#{#}#[#]#(#)#Back",																//KB17
 	".#,#Del##Done#"																	//KB18
 	


### PR DESCRIPTION
When compiling M5ez, two warning were emitted about unknown escape sequences in _keydefs strings.
The first sequence simply needed to escape the `\` with as second `\`. The compiler reduces the `\\` to `\` so the program sees no difference. The compiler's response to the unknown sequence was to accept it, so that's why it used to work.
In the second case, the `#` did not need to be escaped. The `\` was removed by `M5ez::chopStrings()` but everything works fine without it.
Installed on two M5s side by side and exercised the changes well.